### PR TITLE
 Carrito Añadir producto Por fin (Fran Hidalgo)

### DIFF
--- a/_clases.php
+++ b/_clases.php
@@ -191,9 +191,9 @@ abstract class ProtoPedido extends Dato
         $this->lineas = $lineas;
     }
 
-    // TODO No hace falta recibir cliente id.
-    public function variarProducto($clienteId, $productoId, $variacionUnidades) {
-        $nuevaCantidadUnidades = DAO::carritoVariarUnidadesProducto($clienteId, $productoId, $variacionUnidades);
+
+    public function variarProducto($productoId, $variacionUnidades) {
+        $nuevaCantidadUnidades = DAO::carritoVariarUnidadesProducto($this->getClienteId(),$productoId, $variacionUnidades);
 
         $lineas = $this->getLineas();
         $lineaNueva= new LineaCarrito($productoId, $nuevaCantidadUnidades);

--- a/carrito-gestionar-producto.php
+++ b/carrito-gestionar-producto.php
@@ -1,12 +1,13 @@
 <?php
-
+require_once "_clases.php";
 require_once "_dao.php";
-$clienteId = 1; //$_SESSION["id"];  Lo dejamos en 1 considerando que es el usuario "jlopez"
+
+$clienteId = 1; //$_SESSION["id"]; // Lo dejamos en 1 considerando que es el usuario "jlopez"
 $productoId = $_REQUEST["productoId"];
 $variacionUnidades = $_REQUEST["variacionUnidades"];
 
 $carrito = DAO::carritoObtenerParaCliente($clienteId);
 
-$carrito->variarProducto($clienteId, $productoId, $variacionUnidades);
+$carrito->variarProducto($productoId, $variacionUnidades);
 
 ?>


### PR DESCRIPTION
Modificacion en la clase Carrito dentro de _clases.php porque $clienteId era innecesario. Modificacion general de todos los métodos relacionados con Carrito en la clase _dao.php. Parametro de $clienteId eliminado (por lo dicho al principio) al llamar a variarProducto() en carrito-gestionar-producto.php.
Me siento bastante realizado ahora mismo aunque seguramente habrá que darle una vuelta al metodo establecerUnidadesProductos del _dao para eliminar un producto.