### PR TITLE
Arreglo direccion pedido & cliente

### DIFF
--- a/_com/dao.php
+++ b/_com/dao.php
@@ -276,15 +276,26 @@ class DAO
 
     /* PEDIDO */
 
-    public static function pedidoConfirmar(int $pedidoId)
+    public static function pedidoConfirmar(int $pedidoId, $nuevaDireccion)
     {
-        $direccion = DAO::clienteObtenerPorId($_SESSION["id"])->getDireccion();
-        $fechaAhora = obtenerFecha();
-        self::pedidoFijarPrecios($pedidoId);
-        self::ejecutarActualizacion(
-            "UPDATE pedido SET fechaConfirmacion=?, direccionEnvio=? WHERE id=?",
-            [$fechaAhora, $direccion, $pedidoId]
-        );
+        if( !isset($nuevaDireccion)){
+            $direccion = DAO::clienteObtenerPorId($_SESSION["id"])->getDireccion();
+            $fechaAhora = obtenerFecha();
+            self::pedidoFijarPrecios($pedidoId);
+            self::ejecutarActualizacion(
+                "UPDATE pedido SET fechaConfirmacion=?, direccionEnvio=? WHERE id=?",
+                [$fechaAhora, $direccion, $pedidoId]
+            );
+        }else{
+            $direccion = $nuevaDireccion;
+            $fechaAhora = obtenerFecha();
+            self::pedidoFijarPrecios($pedidoId);
+            self::ejecutarActualizacion(
+                "UPDATE pedido SET fechaConfirmacion=?, direccionEnvio=? WHERE id=?",
+                [$fechaAhora, $direccion, $pedidoId]
+            );
+    }
+
     }
 
     private static function pedidoFijarPrecios(int $pedidoId)

--- a/cli/cliente-detalle-guardar.php
+++ b/cli/cliente-detalle-guardar.php
@@ -2,7 +2,12 @@
 
 require_once "../_com/comunes-app.php";
 
-if (isset($_REQUEST['actualizarDireccion'])){
+if (isset($_REQUEST['sobreescribirDireccion']) && isset($_REQUEST['direccion'])){
     DAO::clienteActualizarDireccion($_REQUEST['direccion']);
-    redireccionar($_SERVER['HTTP_REFERER']); // volver a la pagina que me llamo
+    //redireccionar($_SERVER['HTTP_REFERER']); // volver a la pagina que me llamo
+    redireccionar("pedido-crear.php?confirmado=true");
+}else if(isset($_REQUEST['direccion']) && !isset($_REQUEST['sobreescribirDireccion'])){
+    redireccionar("pedido-crear.php?confirmado=true&direccion=".$_REQUEST['direccion']);
+}else{
+    redireccionar("pedido-crear.php?confirmado=true");
 }

--- a/cli/cliente-detalle-guardar.php
+++ b/cli/cliente-detalle-guardar.php
@@ -6,8 +6,8 @@ if (isset($_REQUEST['sobreescribirDireccion']) && isset($_REQUEST['direccion']))
     DAO::clienteActualizarDireccion($_REQUEST['direccion']);
     //redireccionar($_SERVER['HTTP_REFERER']); // volver a la pagina que me llamo
     redireccionar("pedido-crear.php?confirmado=true");
-}else if(isset($_REQUEST['direccion']) && !isset($_REQUEST['sobreescribirDireccion'])){
+}else if(isset($_REQUEST['direccion'])!="" && !isset($_REQUEST['sobreescribirDireccion'])){
     redireccionar("pedido-crear.php?confirmado=true&direccion=".$_REQUEST['direccion']);
 }else{
-    redireccionar("pedido-crear.php?confirmado=true");
+    redireccionar("pedido-crear.php?confirmado=true&direccion=''");
 }

--- a/cli/pedido-crear.php
+++ b/cli/pedido-crear.php
@@ -2,14 +2,13 @@
 
 require_once "../_com/comunes-app.php";
 
-if (isset($_REQUEST['confirmado']) && isset($_REQUEST['direccion'])){
-    $pedidoId = DAO::carritoObtenerId($_SESSION["id"]);
-
-    DAO::pedidoConfirmar($pedidoId, $_REQUEST['direccion']);
-    redireccionar("pedido-finalizado.php");
-}else{
+if (isset($_REQUEST['confirmado']) && $_REQUEST['direccion']==""){
     $pedidoId = DAO::carritoObtenerId($_SESSION["id"]);
     $cliente= DAO::clienteObtenerPorId($_SESSION["id"]);
     DAO::pedidoConfirmar($pedidoId, $cliente->getDireccion());
-    redireccionar("pedido-finalizado.php");
+    redireccionar("pedido-finalizado.php?1=1");
+}else{
+    $pedidoId = DAO::carritoObtenerId($_SESSION["id"]);
+    DAO::pedidoConfirmar($pedidoId, $_REQUEST['direccion']);
+    redireccionar("pedido-finalizado.php?1=2&2=".$_REQUEST['direccion']);
 }

--- a/cli/pedido-crear.php
+++ b/cli/pedido-crear.php
@@ -2,8 +2,14 @@
 
 require_once "../_com/comunes-app.php";
 
-if (isset($_REQUEST['confirmado'])){
+if (isset($_REQUEST['confirmado']) && isset($_REQUEST['direccion'])){
     $pedidoId = DAO::carritoObtenerId($_SESSION["id"]);
-    DAO::pedidoConfirmar($pedidoId);
+
+    DAO::pedidoConfirmar($pedidoId, $_REQUEST['direccion']);
+    redireccionar("pedido-finalizado.php");
+}else{
+    $pedidoId = DAO::carritoObtenerId($_SESSION["id"]);
+    $cliente= DAO::clienteObtenerPorId($_SESSION["id"]);
+    DAO::pedidoConfirmar($pedidoId, $cliente->getDireccion());
     redireccionar("pedido-finalizado.php");
 }

--- a/cli/pedido-previsualizar.php
+++ b/cli/pedido-previsualizar.php
@@ -68,13 +68,28 @@ if ($cliente->getDireccion() != null){
     </tbody>
 </table>
 <h3>Dirección de envío</h3>
+
+<p>Tu dirección predeterminada es: <?= $direccion?></p>
+
 <form action="cliente-detalle-guardar.php" method="get">
-    <input type="hidden" name="actualizarDireccion" value="true">
-    <input type="text" name="direccion" value="<?= $direccion?>" required>
-    <input type="submit" value="Actualizar">
+    <!--<input type="hidden" name="actualizarDireccion" value="true">-->
+    <input type="text" name="direccion"  placeholder="Inserte otra dirección de envío" style="WIDTH: 200px">
+    <br>
+    <input type="checkbox" name="sobreescribirDireccion">
+    <label for "sobreescribirDireccion">Usar esta dirección como predeterminada</label>
+    <br>
+    <br>
+    <input type="submit" name="confirmarPedido" value="Confirmar pedido">
+
 </form>
-<a href="pedido-crear.php?confirmado=true">Finalizar Compra</a>
+
+<!--<button><a href="pedido-crear.php?confirmado=true">Finalizar Compra</a></button>-->
+
+<br>
+<br>
+
 <a href="productos-listado.php">Seguir Comprando</a>
+
 <?php require "../_com/info-sesion.php"; ?>
 
 

--- a/cli/pedido-previsualizar.php
+++ b/cli/pedido-previsualizar.php
@@ -9,6 +9,8 @@ $direccion = "";
 
 if ($cliente->getDireccion() != null){
     $direccion = $cliente->getDireccion();
+}else{
+    $direccion= "No tiene dirección peredeterminada, especifíquela abajo.";
 }
 
 ?>


### PR DESCRIPTION
Configuración nueva para la dirección de los pedidos.
Existen 3 casos:
1º - No rellenar dirección y usar la predeterminada
2º - Usar nueva dirección pero no alterarla predeterminada del cliente
3º- Nueva dirección sobreescribiendo la dirección antigua del cliente